### PR TITLE
s3grabber: add ability to specify a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+- 0.2.0
+
+* BREAKING: change `--config-file` into `--config-path`. Now if the provided
+  path points to a file then that file is read as a configuration file; if it
+  points to a directory then all files inside of it (not recursive) with the
+  suffix `.yml` and/or `.yaml` are read and merged into one configuration that
+  is later used. This simplifies deployment with configuration management
+  systems such as Chef where you will be able to have multiple resources that
+  later result in multiple configuration files.
+* BREAKING: move `shell` and `timeout` parameters into `grabbers`. This allows
+  more customization.

--- a/cmd/s3grabber/s3grabber.go
+++ b/cmd/s3grabber/s3grabber.go
@@ -36,7 +36,7 @@ func initializeLogger(logFormat string, logLevel string) log.Logger {
 }
 
 func main() {
-	configFile := kingpin.Flag("config-file", "Path to the configuration file").Required().String()
+	configFile := kingpin.Flag("config-path", "Path to the configuration file or directory").Required().String()
 	logFormat := kingpin.Flag("log-format", "Log format").Default("LOGFMT").Enum("JSON", "LOGFMT")
 	logLevel := kingpin.Flag("log-level", "Log level").Default("DEBUG").Enum("DEBUG", "INFO", "WARN", "ERROR")
 

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,4 @@
 ---
-shell: "/bin/sh"
-timeout: 5s # Max duration for all grabbers.
 buckets:
   lithuania:
     host: foo.bar
@@ -9,6 +7,8 @@ buckets:
     bucket: test
 grabbers:
   alerting_rules:
+    shell: "/bin/sh"
+    timeout: 5s # Max duration for this grabber.
     buckets:
       - lithuania
     file: "alerting_rules.tar.gz"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,23 @@
 version: '3'
 services:
   minio2:
-    image: docker.io/bitnami/minio:2022
+    image: minio/minio:RELEASE.2022-05-03T20-36-08Z
     environment:
       MINIO_ACCESS_KEY: foobar
       MINIO_SECRET_KEY: foobardd
     networks: ["test"]
+    command: server /data
+    volumes:
+      - data2:/data
   minio1:
-    image: docker.io/bitnami/minio:2022
+    image: minio/minio:RELEASE.2022-05-03T20-36-08Z
     environment:
       MINIO_ACCESS_KEY: foobar
       MINIO_SECRET_KEY: foobardd
     networks: ["test"]
+    command: server /data
+    volumes:
+      - data2:/data
   tester:
     networks: ["test"]
     build:
@@ -21,3 +27,7 @@ services:
 
 networks:
   test:
+
+volumes:
+  data:
+  data2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     networks: ["test"]
     command: server /data
     volumes:
-      - data2:/data
+      - data:/data
   tester:
     networks: ["test"]
     build:

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -3,7 +3,9 @@ package cfg
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -44,16 +46,89 @@ type GrabberConfig struct {
 	File     string
 	Path     string
 	Commands []string
-}
-
-type GlobalConfig struct {
-	Buckets  map[string]BucketConfig
-	Grabbers map[string]GrabberConfig
 	Timeout  time.Duration
 	Shell    string
 }
 
+type GlobalConfig struct {
+	Buckets  map[string]BucketConfig  `yaml:"buckets"`
+	Grabbers map[string]GrabberConfig `yaml:"grabbers"`
+}
+
+func (gc *GlobalConfig) Merge(other *GlobalConfig) error {
+	for bucketName := range other.Buckets {
+		if _, ok := gc.Buckets[bucketName]; ok {
+			return fmt.Errorf("found duplicated bucket name %s", bucketName)
+		}
+	}
+
+	for grabberName := range other.Grabbers {
+		if _, ok := gc.Grabbers[grabberName]; ok {
+			return fmt.Errorf("found duplicated grabber name %s", grabberName)
+		}
+	}
+
+	for bucketName := range other.Buckets {
+		gc.Buckets[bucketName] = other.Buckets[bucketName]
+	}
+
+	for grabberName, grabberCfg := range other.Grabbers {
+		if grabberCfg.Shell == "" {
+			grabberCfg.Shell = "/bin/sh"
+		}
+		if grabberCfg.Timeout == 0 {
+			grabberCfg.Timeout = 5 * time.Second
+		}
+		gc.Grabbers[grabberName] = grabberCfg
+	}
+
+	return nil
+}
+
+func readFromPath(originalPath string) (GlobalConfig, error) {
+	cfg := GlobalConfig{
+		Buckets:  map[string]BucketConfig{},
+		Grabbers: map[string]GrabberConfig{},
+	}
+
+	if err := filepath.WalkDir(originalPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == originalPath {
+			return nil
+		}
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+
+		if !strings.HasSuffix(path, ".yml") && !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+
+		fileCfg, err := ReadConfig(path)
+		if err != nil {
+			return fmt.Errorf("reading config from %s: %w", path, err)
+		}
+
+		if err := cfg.Merge(&fileCfg); err != nil {
+			return fmt.Errorf("merging %s: %w", path, err)
+		}
+
+		return nil
+	}); err != nil {
+		return cfg, fmt.Errorf("walking %s: %w", originalPath, err)
+	}
+	return cfg, nil
+}
+
 func ReadConfig(path string) (GlobalConfig, error) {
+	if fi, err := os.Stat(path); err != nil {
+		return GlobalConfig{}, fmt.Errorf("calling stat on %s: %w", path, err)
+	} else if fi.IsDir() {
+		return readFromPath(path)
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return GlobalConfig{}, fmt.Errorf("opening %s: %w", path, err)
@@ -68,14 +143,6 @@ func ReadConfig(path string) (GlobalConfig, error) {
 	ret := GlobalConfig{}
 	if err := yaml.Unmarshal(content, &ret); err != nil {
 		return GlobalConfig{}, fmt.Errorf("parsing YAML %s: %w", path, err)
-	}
-
-	if ret.Shell == "" {
-		ret.Shell = "/bin/sh"
-	}
-
-	if ret.Timeout == 0 {
-		ret.Timeout = 5 * time.Second
 	}
 
 	return ret, nil

--- a/internal/cfg/config_test.go
+++ b/internal/cfg/config_test.go
@@ -2,11 +2,127 @@ package cfg
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+func TestLoadFromPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tcase := range []struct {
+		fileContent map[string]string
+		expectedErr bool
+		name        string
+		expectedCfg GlobalConfig
+	}{
+		{
+			fileContent: map[string]string{
+				"test2.yml": `---
+buckets:
+  lithuania:
+    host: foo.bar
+    access_key: aabb
+    secret_key: bbaa
+    bucket: test
+grabbers:
+  alerting_rules:
+    shell: "/bin/sh"
+    timeout: 5s # Max duration for this grabber.
+    buckets:
+      - lithuania
+    file: "alerting_rules.tar.gz"
+    path: "/etc/prometheus/rules"
+    commands:
+      - "kill -HUP $(pidof prometheus)"`,
+				"test.yml": `---
+buckets:
+  lithuania:
+    host: foo.bar
+    access_key: aabb
+    secret_key: bbaa
+    bucket: test
+grabbers:
+  alerting_rules:
+    shell: "/bin/sh"
+    timeout: 5s # Max duration for this grabber.
+    buckets:
+      - lithuania
+    file: "alerting_rules.tar.gz"
+    path: "/etc/prometheus/rules"
+    commands:
+      - "kill -HUP $(pidof prometheus)"`,
+			},
+			expectedErr: true,
+			name:        "duplicated names",
+		},
+		{
+			name: "proper load",
+			fileContent: map[string]string{
+				"test2.yml": `---
+buckets:
+  aaa:
+    host: foo.bar
+    access_key: aabb
+    secret_key: bbaa
+    bucket: test
+grabbers:
+  bbb:
+    shell: "/bin/sh"
+    timeout: 5s # Max duration for this grabber.
+    buckets:
+      - aaa
+    file: "alerting_rules.tar.gz"
+    path: "/etc/prometheus/rules"
+    commands:
+      - "kill -HUP $(pidof prometheus)"`,
+				"test.yml": `---
+buckets:
+  fff:
+    host: foo.bar
+    access_key: aabb
+    secret_key: bbaa
+    bucket: test
+grabbers:
+  bbb:
+    shell: "/bin/sh"
+    timeout: 5s # Max duration for this grabber.
+    buckets:
+      - fff
+    file: "alerting_rules.tar.gz"
+    path: "/etc/prometheus/rules"
+    commands:
+      - "kill -HUP $(pidof prometheus)"`,
+			},
+			expectedCfg: GlobalConfig{
+				Buckets:  map[string]BucketConfig{"fff": {Host: "foo.bar", AccessKey: "aabb", SecretKey: "bbaa", Bucket: "test"}},
+				Grabbers: map[string]GrabberConfig{"bbb": {Buckets: []string{"fff"}, File: "alerting_rules.tar.gz", Path: "/etc/prometheus/rules", Commands: []string{"kill -HUP $(pidof prometheus)"}, Timeout: 5000000000, Shell: "/bin/sh"}},
+			},
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			tmpDir := filepath.Join(os.TempDir(), "downloader-test")
+			t.Cleanup(func() {
+				_ = os.RemoveAll(tmpDir)
+			})
+			require.Nil(t, os.MkdirAll(tmpDir, os.ModePerm))
+
+			for fname, content := range tcase.fileContent {
+				require.NoError(t, os.WriteFile(filepath.Join(tmpDir, fname), []byte(content), os.ModePerm))
+			}
+
+			cfg, err := readFromPath(tmpDir)
+			if tcase.expectedErr {
+				require.NotNil(t, err)
+				return
+			}
+
+			require.Equal(t, tcase.expectedCfg, cfg)
+		})
+	}
+}
 
 func TestCredentialLoad(t *testing.T) {
 	os.Setenv("test", "foo")

--- a/internal/cfg/config_test.go
+++ b/internal/cfg/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -30,7 +31,6 @@ buckets:
 grabbers:
   alerting_rules:
     shell: "/bin/sh"
-    timeout: 5s # Max duration for this grabber.
     buckets:
       - lithuania
     file: "alerting_rules.tar.gz"
@@ -47,7 +47,6 @@ buckets:
 grabbers:
   alerting_rules:
     shell: "/bin/sh"
-    timeout: 5s # Max duration for this grabber.
     buckets:
       - lithuania
     file: "alerting_rules.tar.gz"
@@ -71,7 +70,6 @@ buckets:
 grabbers:
   bbb:
     shell: "/bin/sh"
-    timeout: 5s # Max duration for this grabber.
     buckets:
       - aaa
     file: "alerting_rules.tar.gz"
@@ -88,7 +86,6 @@ buckets:
 grabbers:
   bbb:
     shell: "/bin/sh"
-    timeout: 5s # Max duration for this grabber.
     buckets:
       - fff
     file: "alerting_rules.tar.gz"
@@ -98,7 +95,7 @@ grabbers:
 			},
 			expectedCfg: GlobalConfig{
 				Buckets:  map[string]BucketConfig{"fff": {Host: "foo.bar", AccessKey: "aabb", SecretKey: "bbaa", Bucket: "test"}},
-				Grabbers: map[string]GrabberConfig{"bbb": {Buckets: []string{"fff"}, File: "alerting_rules.tar.gz", Path: "/etc/prometheus/rules", Commands: []string{"kill -HUP $(pidof prometheus)"}, Timeout: 5000000000, Shell: "/bin/sh"}},
+				Grabbers: map[string]GrabberConfig{"bbb": {Buckets: []string{"fff"}, File: "alerting_rules.tar.gz", Path: "/etc/prometheus/rules", Commands: []string{"kill -HUP $(pidof prometheus)"}, Timeout: 5 * time.Second, Shell: "/bin/sh"}},
 			},
 		},
 	} {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -98,9 +98,10 @@ type Installer struct {
 	bm       *downloader.BucketManager
 	shellCmd string
 	logger   log.Logger
+	timeout  time.Duration
 }
 
-func NewInstaller(bm *downloader.BucketManager, commands []string, bucketPath, installInto string, shellCmd string, logger log.Logger) *Installer {
+func NewInstaller(bm *downloader.BucketManager, commands []string, bucketPath, installInto string, shellCmd string, timeout time.Duration, logger log.Logger) *Installer {
 	return &Installer{
 		bm:                      bm,
 		lastModTimeByObjectPath: make(map[string]time.Time),
@@ -109,7 +110,12 @@ func NewInstaller(bm *downloader.BucketManager, commands []string, bucketPath, i
 		bucketPath:              bucketPath,
 		shellCmd:                shellCmd,
 		logger:                  logger,
+		timeout:                 timeout,
 	}
+}
+
+func (i *Installer) GetTimeout() time.Duration {
+	return i.timeout
 }
 
 func (i *Installer) Install(ctx context.Context) error {

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -48,8 +48,6 @@ func TestS3GrabberMain(t *testing.T) {
 				Commands: []string{fmt.Sprintf("echo foobar > %s", filepath.Join(tmpDir, "somefile"))},
 			},
 		},
-		Timeout: 5 * time.Second,
-		Shell:   "/bin/sh",
 	}
 	err := s3grabber.RunS3Grabber(log.NewLogfmtLogger(os.Stderr), grabberCfg)
 	require.NotNil(t, err)

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -46,11 +46,14 @@ func TestS3GrabberMain(t *testing.T) {
 				File:     "example.tar.gz",
 				Path:     tmpDir,
 				Commands: []string{fmt.Sprintf("echo foobar > %s", filepath.Join(tmpDir, "somefile"))},
+				Timeout:  5 * time.Second,
+				Shell:    "/bin/sh",
 			},
 		},
 	}
 	err := s3grabber.RunS3Grabber(log.NewLogfmtLogger(os.Stderr), grabberCfg)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "The specified bucket does not exist")
 
 	// Upload the file to both buckets.
 	time.Sleep(1 * time.Second) // To ensure ctime < modify time.
@@ -58,6 +61,7 @@ func TestS3GrabberMain(t *testing.T) {
 		grabberCfg.Buckets["test1"], grabberCfg.Buckets["test2"],
 	})
 	require.NoError(t, err)
+
 	// Only upload to one bucket to check whether it works properly.
 	require.NoError(t, bm.CreateBucket(context.Background(), "test", 0))
 	require.NoError(t, bm.CreateBucket(context.Background(), "test", 1))

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -50,21 +50,21 @@ func TestS3GrabberMain(t *testing.T) {
 		},
 	}
 	err := s3grabber.RunS3Grabber(log.NewLogfmtLogger(os.Stderr), grabberCfg)
-	require.NotNil(t, err)
+	require.NoError(t, err)
 
 	// Upload the file to both buckets.
 	time.Sleep(1 * time.Second) // To ensure ctime < modify time.
 	bm, err := downloader.NewBucketManager([]cfg.BucketConfig{
 		grabberCfg.Buckets["test1"], grabberCfg.Buckets["test2"],
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// Only upload to one bucket to check whether it works properly.
-	require.Nil(t, bm.CreateBucket(context.Background(), "test", 0))
-	require.Nil(t, bm.CreateBucket(context.Background(), "test", 1))
-	require.Nil(t, bm.PutFile(context.Background(), "../internal/downloader/example.tar.gz", "/example.tar.gz", 1))
+	require.NoError(t, bm.CreateBucket(context.Background(), "test", 0))
+	require.NoError(t, bm.CreateBucket(context.Background(), "test", 1))
+	require.NoError(t, bm.PutFile(context.Background(), "../internal/downloader/example.tar.gz", "/example.tar.gz", 1))
 
 	err = s3grabber.RunS3Grabber(log.NewLogfmtLogger(os.Stderr), grabberCfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checkFileContentEqual(t, filepath.Join(tmpDir, "test"), "Hello world!\n")
 	checkFileContentEqual(t, filepath.Join(tmpDir, "somefile"), "foobar\n")


### PR DESCRIPTION
Add the ability to specify a path instead of just one single file to
make deployments easier. This also means that `shell` and `timeout`
parameters have to be moved into `grabbers` because otherwise it would
not be clear how to solve collisions.

Tested with a unit test.