### PR TITLE
s3grabber: fix concurrent map writes

### DIFF
--- a/internal/s3grabber/main.go
+++ b/internal/s3grabber/main.go
@@ -36,6 +36,7 @@ func RunS3Grabber(logger log.Logger, config cfg.GlobalConfig) error {
 	defer cancel()
 
 	for _, i := range installers {
+		i := *i
 		g.Add(func() error {
 			ctx, cancel := context.WithTimeout(gctx, i.GetTimeout())
 			defer cancel()


### PR DESCRIPTION
Currently, s3grabber might crash due to:

```
s3grabber[25021]: fatal error: concurrent map writes
s3grabber[25021]: goroutine 138 [running]:
s3grabber[25021]: runtime.throw({0xa01660, 0x9a4b20})
s3grabber[25021]: /opt/hostedtoolcache/go/1.17.10/x64/src/runtime/panic.go:1198 +0x71 fp=0xc0003d9bb8 sp=0xc0003d9b88 pc=0x435bd1
s3grabber[25021]: runtime.mapassign_faststr(0x95dde0, 0xc0000c2c90, {0xc0002bd020, 0x1d})
s3grabber[25021]: /opt/hostedtoolcache/go/1.17.10/x64/src/runtime/map_faststr.go:294 +0x38b fp=0xc0003d9c20 sp=0xc0003d9bb8 pc=0x41300b
s3grabber[25021]: github.com/vinted/S3Grabber/internal/installer.(*Installer).checkLastModTime(0xc0000e1ce0, {0xac4030, 0xc000280060}, {0x
s3grabber[25021]: /home/runner/work/S3Grabber/S3Grabber/internal/installer/installer.go:221 +0x7b4 fp=0xc0003d9d48 sp=0xc0003d9c20 pc=0x8b
s3grabber[25021]: github.com/vinted/S3Grabber/internal/installer.(*Installer).Install(0xc0000e1ce0, {0xac4030, 0xc000280060})
s3grabber[25021]: /home/runner/work/S3Grabber/S3Grabber/internal/installer/installer.go:148 +0x3af fp=0xc0003d9f38 sp=0xc0003d9d48 pc=0x8b
```

Installers don't share anything between them so I think this might
happen to the loop here - run.Group{} has a closure on `i` which is
range-loop variable i.e. it is always the same pointer but just that on
each iteration points to a different Installer. Thus, let's make a
copy of the pointer to each installer during the loop to fix this.

It is hard to reproduce this so not adding any tests.