### PR TITLE
s3grabber: write into temp dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/otiai10/copy v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,12 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
+github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func TestDownloadFile(t *testing.T) {
 		})
 		assert.Nil(t, os.MkdirAll(tmpDir, os.ModePerm))
 
-		assert.Nil(t, installer.ExtractTarGz(tmpDir, rc))
+		assert.Nil(t, installer.ExtractTarGz(log.NewNopLogger(), "foo", tmpDir, rc))
 		f, err := os.Open(filepath.Join(tmpDir, "test"))
 		assert.Nil(t, err)
 		t.Cleanup(func() {

--- a/internal/s3grabber/main.go
+++ b/internal/s3grabber/main.go
@@ -28,7 +28,7 @@ func RunS3Grabber(logger log.Logger, config cfg.GlobalConfig) error {
 			return fmt.Errorf("constructing bucket manager for grabber %s: %w", grabberName, err)
 		}
 
-		installers = append(installers, installer.NewInstaller(bm, grabber.Commands, grabber.File, grabber.Path, grabber.Shell, grabber.Timeout, logger))
+		installers = append(installers, installer.NewInstaller(grabberName, bm, grabber.Commands, grabber.File, grabber.Path, grabber.Shell, grabber.Timeout, logger))
 	}
 
 	g := &run.Group{}
@@ -42,8 +42,10 @@ func RunS3Grabber(logger log.Logger, config cfg.GlobalConfig) error {
 			defer cancel()
 
 			return i.Install(ctx)
-		}, func(error) {
-			cancel()
+		}, func(e error) {
+			if e != nil {
+				cancel()
+			}
 		})
 	}
 


### PR DESCRIPTION
First write into a temporary directory so that we wouldn't get into a
temporary state with some files extracted.

Also, only cancel the work if there has been a non-nil error.