### PR TITLE
feature: add resolve_ip option

### DIFF
--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -36,6 +36,7 @@ func (c *credentialString) UnmarshalYAML(unmarshal func(interface{}) error) erro
 
 type BucketConfig struct {
 	Host      string
+	ResolveIP bool             `yaml:"resolve_ip"` // controls if given host should be resolved to IP for usage in client, first returned IP is used
 	AccessKey credentialString `yaml:"access_key"`
 	SecretKey credentialString `yaml:"secret_key"`
 	Bucket    string

--- a/internal/cfg/config_test.go
+++ b/internal/cfg/config_test.go
@@ -98,6 +98,41 @@ grabbers:
 				Grabbers: map[string]GrabberConfig{"bbb": {Buckets: []string{"fff"}, File: "alerting_rules.tar.gz", Path: "/etc/prometheus/rules", Commands: []string{"kill -HUP $(pidof prometheus)"}, Timeout: 5 * time.Second, Shell: "/bin/sh"}},
 			},
 		},
+		{
+			name: "config with ResolveIP",
+			fileContent: map[string]string{
+				"test3.yml": `---
+buckets:
+  aaa:
+    host: foo.bar
+    access_key: aabb
+    secret_key: bbaa
+    bucket: test
+  bbb:
+    host: foo.bar
+    resolve_ip: true
+    access_key: aabb
+    secret_key: bbaa
+    bucket: test
+grabbers:
+  fff:
+    shell: "/bin/sh"
+    buckets:
+      - aaa
+      - bbb
+    file: "alerting_rules.tar.gz"
+    path: "/etc/prometheus/rules"
+    commands:
+      - "kill -HUP $(pidof prometheus)"`,
+			},
+			expectedCfg: GlobalConfig{
+				Buckets: map[string]BucketConfig{
+					"aaa": {Host: "foo.bar", ResolveIP: false, AccessKey: "aabb", SecretKey: "bbaa", Bucket: "test"},
+					"bbb": {Host: "foo.bar", ResolveIP: true, AccessKey: "aabb", SecretKey: "bbaa", Bucket: "test"},
+				},
+				Grabbers: map[string]GrabberConfig{"fff": {Buckets: []string{"aaa", "bbb"}, File: "alerting_rules.tar.gz", Path: "/etc/prometheus/rules", Commands: []string{"kill -HUP $(pidof prometheus)"}, Timeout: 5 * time.Second, Shell: "/bin/sh"}},
+			},
+		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			tmpDir := filepath.Join(os.TempDir(), "downloader-test")


### PR DESCRIPTION
We have some special case where we use dc specific Ceph DNS name, but it is not allowed as S3 does not allow multiple DNS names of bucket.

Implement workaround resolve IP of given DNS name.