### PR TITLE
downloader: support custom host header

### DIFF
--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -36,10 +36,11 @@ func (c *credentialString) UnmarshalYAML(unmarshal func(interface{}) error) erro
 }
 
 type BucketConfig struct {
-	Host      string
-	AccessKey credentialString `yaml:"access_key"`
-	SecretKey credentialString `yaml:"secret_key"`
-	Bucket    string
+	Host             string
+	AccessKey        credentialString `yaml:"access_key"`
+	SecretKey        credentialString `yaml:"secret_key"`
+	Bucket           string
+	CustomHostHeader string `yaml:"custom_host_header"`
 }
 
 type GrabberConfig struct {


### PR DESCRIPTION
Set custom Host header by setting it in the roundtripper + resign the whole request to accomodate these changes.