### PR TITLE
Fix handling of removed upstream files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## [0.10.0](https://github.com/vinted/S3Grabber/releases/tag/0.10.0)
 
-* Added automatic deletion of files from local storage when they are deleted from
-  the S3 bucket. S3Grabber now synchronizes not only new and updated files but
-  also removes files locally that no longer exist in the remote S3 storage.
-* **Heads Up**: This version changes the synchronization behavior. Files deleted
-  from the S3 bucket will now be automatically removed from the local storage.
-  If you have files in your local directory that you want to preserve independently
-  from S3, please review your setup before upgrading.
+* Added automatic deletion of files from local storage for directory/prefix-based
+  grabbers when the corresponding objects are deleted from the S3 bucket.
+  S3Grabber now synchronizes not only new and updated files but also removes
+  local files for these grabbers that no longer exist in the remote S3 storage.
+* **Heads Up**: This version changes the synchronization behavior for
+  directory/prefix-based grabbers. Files deleted from the S3 bucket for those
+  grabbers will now be automatically removed from the local storage. If you
+  have files in your local directory that you want to preserve independently
+  from S3, please review your setup before upgrading (archive grabbers are not
+  affected by this change).
 
 ## [0.3.0](https://github.com/vinted/S3Grabber/releases/tag/0.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.10.0](https://github.com/vinted/S3Grabber/releases/tag/0.10.0)
+
+* Added automatic deletion of files from local storage when they are deleted from
+  the S3 bucket. S3Grabber now synchronizes not only new and updated files but
+  also removes files locally that no longer exist in the remote S3 storage.
+* **Heads Up**: This version changes the synchronization behavior. Files deleted
+  from the S3 bucket will now be automatically removed from the local storage.
+  If you have files in your local directory that you want to preserve independently
+  from S3, please review your setup before upgrading.
+
 ## [0.3.0](https://github.com/vinted/S3Grabber/releases/tag/0.3.0)
 
 * Added waiting mode. Now if `--interval` is passed and it is not zero then

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -232,6 +232,7 @@ func (m *BucketManager) FindNewestInPrefix(ctx context.Context, prefix string) (
 	return
 }
 
+// ListFiles lists all the files in the provided prefix across all buckets.
 func (m *BucketManager) ListFiles(ctx context.Context, prefix string) ([]string, error) {
 	if len(m.clients) == 0 {
 		return nil, fmt.Errorf("no clients configured")
@@ -260,6 +261,10 @@ func (m *BucketManager) ListFiles(ctx context.Context, prefix string) ([]string,
 		}
 	}
 	return files, errs
+}
+
+func (m *BucketManager) Buckets() []string {
+	return m.bucketNames
 }
 
 type hostHeaderAddRoundtripper struct {

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -137,6 +137,14 @@ func (m *BucketManager) PutFile(ctx context.Context, filePath, bucketPath string
 	return nil
 }
 
+// DeleteFile deletes the given file from the given path. Use only for tests.
+func (m *BucketManager) DeleteFile(ctx context.Context, bucketPath string, bucketIndex int) error {
+	if err := m.indexInBounds(bucketIndex); err != nil {
+		return err
+	}
+	return m.clients[bucketIndex].RemoveObject(ctx, m.bucketNames[bucketIndex], bucketPath, minio.RemoveObjectOptions{})
+}
+
 // FindNewestFile finds the newest file in all of the buckets with the provided path.
 // Returns the modification time and bucket index that later on needs to be passed to GetFile.
 func (m *BucketManager) FindNewestFile(ctx context.Context, path string) (modTime time.Time, bucketIndex int, err error) {
@@ -180,15 +188,54 @@ func (m *BucketManager) FindNewestFile(ctx context.Context, path string) (modTim
 // FindNewestInPrefix finds the newest file in all of the buckets for the provided prefix.
 // Returns the modification time and bucket index that later on needs to be passed to GetFiles.
 func (m *BucketManager) FindNewestInPrefix(ctx context.Context, prefix string) (modTime time.Time, bucketIndex int, err error) {
+	objects, errs := m.listObjects(ctx, prefix)
+	var checkedOne bool
+	for _, objInfo := range objects {
+		if objInfo.lastModified.After(modTime) {
+			modTime = objInfo.lastModified
+			bucketIndex = objInfo.bucketIndex
+			checkedOne = true
+		}
+	}
+
+	if !checkedOne {
+		if errs != nil {
+			return modTime, bucketIndex, errs
+		}
+		return modTime, bucketIndex, fmt.Errorf("no file has been modified so either they do not exist or there are time synchronization problems")
+	}
+	return
+}
+
+func (m *BucketManager) ListFiles(ctx context.Context, prefix string) ([]string, error) {
+	objects, err := m.listObjects(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	for _, objInfo := range objects {
+		files = append(files, objInfo.key)
+	}
+	return files, nil
+}
+
+type objectInfo struct {
+	key          string
+	lastModified time.Time
+	bucketIndex  int
+}
+
+func (m *BucketManager) listObjects(ctx context.Context, prefix string) ([]objectInfo, error) {
 	if len(m.clients) == 0 {
-		return modTime, bucketIndex, fmt.Errorf("no clients configured")
+		return nil, fmt.Errorf("no clients configured")
 	}
 
 	const notFoundCode = "NoSuchKey"
 
 	var (
-		errs       error
-		checkedOne bool
+		errs    error
+		objects []objectInfo
 	)
 
 	if !strings.HasSuffix(prefix, "/") {
@@ -207,21 +254,14 @@ func (m *BucketManager) FindNewestInPrefix(ctx context.Context, prefix string) (
 				continue
 			}
 
-			if objInfo.LastModified.After(modTime) {
-				modTime = objInfo.LastModified
-				bucketIndex = i
-				checkedOne = true
-			}
+			objects = append(objects, objectInfo{
+				key:          objInfo.Key,
+				lastModified: objInfo.LastModified,
+				bucketIndex:  i,
+			})
 		}
 	}
-
-	if !checkedOne {
-		if errs != nil {
-			return modTime, bucketIndex, errs
-		}
-		return modTime, bucketIndex, fmt.Errorf("no file has been modified so either they do not exist or there are time synchronization problems")
-	}
-	return
+	return objects, errs
 }
 
 type hostHeaderAddRoundtripper struct {

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -188,54 +188,15 @@ func (m *BucketManager) FindNewestFile(ctx context.Context, path string) (modTim
 // FindNewestInPrefix finds the newest file in all of the buckets for the provided prefix.
 // Returns the modification time and bucket index that later on needs to be passed to GetFiles.
 func (m *BucketManager) FindNewestInPrefix(ctx context.Context, prefix string) (modTime time.Time, bucketIndex int, err error) {
-	objects, errs := m.listObjects(ctx, prefix)
-	var checkedOne bool
-	for _, objInfo := range objects {
-		if objInfo.lastModified.After(modTime) {
-			modTime = objInfo.lastModified
-			bucketIndex = objInfo.bucketIndex
-			checkedOne = true
-		}
-	}
-
-	if !checkedOne {
-		if errs != nil {
-			return modTime, bucketIndex, errs
-		}
-		return modTime, bucketIndex, fmt.Errorf("no file has been modified so either they do not exist or there are time synchronization problems")
-	}
-	return
-}
-
-func (m *BucketManager) ListFiles(ctx context.Context, prefix string) ([]string, error) {
-	objects, err := m.listObjects(ctx, prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	var files []string
-	for _, objInfo := range objects {
-		files = append(files, objInfo.key)
-	}
-	return files, nil
-}
-
-type objectInfo struct {
-	key          string
-	lastModified time.Time
-	bucketIndex  int
-}
-
-func (m *BucketManager) listObjects(ctx context.Context, prefix string) ([]objectInfo, error) {
 	if len(m.clients) == 0 {
-		return nil, fmt.Errorf("no clients configured")
+		return modTime, bucketIndex, fmt.Errorf("no clients configured")
 	}
 
 	const notFoundCode = "NoSuchKey"
 
 	var (
-		errs    error
-		objects []objectInfo
+		errs       error
+		checkedOne bool
 	)
 
 	if !strings.HasSuffix(prefix, "/") {
@@ -254,14 +215,51 @@ func (m *BucketManager) listObjects(ctx context.Context, prefix string) ([]objec
 				continue
 			}
 
-			objects = append(objects, objectInfo{
-				key:          objInfo.Key,
-				lastModified: objInfo.LastModified,
-				bucketIndex:  i,
-			})
+			if objInfo.LastModified.After(modTime) {
+				modTime = objInfo.LastModified
+				bucketIndex = i
+				checkedOne = true
+			}
 		}
 	}
-	return objects, errs
+
+	if !checkedOne {
+		if errs != nil {
+			return modTime, bucketIndex, errs
+		}
+		return modTime, bucketIndex, fmt.Errorf("no file has been modified so either they do not exist or there are time synchronization problems")
+	}
+	return
+}
+
+func (m *BucketManager) ListFiles(ctx context.Context, prefix string) ([]string, error) {
+	if len(m.clients) == 0 {
+		return nil, fmt.Errorf("no clients configured")
+	}
+
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
+
+	const notFoundCode = "NoSuchKey"
+	var errs error
+	var files []string
+	for i, cl := range m.clients {
+		objCh := cl.ListObjects(ctx, m.bucketNames[i], minio.ListObjectsOptions{Prefix: prefix})
+		for objInfo := range objCh {
+			err := objInfo.Err
+			if err != nil && minio.ToErrorResponse(err).Code != notFoundCode {
+				errs = multierror.Append(errs, err)
+				continue
+			}
+			if minio.ToErrorResponse(err).Code == notFoundCode {
+				continue
+			}
+
+			files = append(files, objInfo.Key)
+		}
+	}
+	return files, errs
 }
 
 type hostHeaderAddRoundtripper struct {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -139,7 +139,7 @@ type Installer struct {
 type extracter interface {
 	findNewestFile(ctx context.Context) (lastUpdated time.Time, bucketIndex int, err error)
 	extractFiles(ctx context.Context, bucketIndex int) (bool, error)
-	checkMissingFiles(ctx context.Context, installInto string) (bool, error)
+	checkMissingFiles(ctx context.Context) (bool, error)
 }
 
 func NewArchiveInstaller(name string, bm *downloader.BucketManager, commands []string, bucketPath, installInto string, shellCmd string, timeout time.Duration, replacePrefix string, logger log.Logger) *Installer {
@@ -219,9 +219,9 @@ func (i *Installer) Install(ctx context.Context) (attemptedInstall bool, rerr er
 	}
 
 	if !doInstall {
-		hasMissingFiles, err := i.extracter.checkMissingFiles(ctx, i.installInto)
+		hasMissingFiles, err := i.extracter.checkMissingFiles(ctx)
 		if err != nil {
-			_ = level.Debug(i.logger).Log("msg", "failed to check for missing files", "err", err.Error(), "dir", i.installInto)
+			_ = level.Error(i.logger).Log("msg", "failed to check for missing files", "err", err.Error(), "dir", i.installInto)
 		} else if hasMissingFiles {
 			_ = level.Debug(i.logger).Log("msg", "executing installation because files are missing", "dir", i.installInto, "path", i.bucketPath)
 			doInstall = true
@@ -305,7 +305,7 @@ func (e *archiveExtracter) findNewestFile(ctx context.Context) (lastUpdated time
 	return e.bm.FindNewestFile(ctx, e.bucketPath)
 }
 
-func (e *archiveExtracter) checkMissingFiles(ctx context.Context, installInto string) (bool, error) {
+func (e *archiveExtracter) checkMissingFiles(ctx context.Context) (bool, error) {
 	// note: in archive case it is sufficient to rely on the modification time check
 	return false, nil
 }
@@ -338,7 +338,7 @@ func (e *directoryExtracter) findNewestFile(ctx context.Context) (lastUpdated ti
 	return e.bm.FindNewestInPrefix(ctx, e.bucketPrefix)
 }
 
-func (e *directoryExtracter) checkMissingFiles(ctx context.Context, installInto string) (bool, error) {
+func (e *directoryExtracter) checkMissingFiles(ctx context.Context) (bool, error) {
 	remoteFiles, err := e.bm.ListFiles(ctx, e.bucketPrefix)
 	if err != nil {
 		return false, fmt.Errorf("listing files in bucket: %w", err)
@@ -349,9 +349,9 @@ func (e *directoryExtracter) checkMissingFiles(ctx context.Context, installInto 
 		remoteMap[path.Base(targetPath)] = struct{}{}
 	}
 
-	localEntries, err := os.ReadDir(installInto)
+	localEntries, err := os.ReadDir(e.installInto)
 	if err != nil {
-		return false, fmt.Errorf("reading dir %s: %w", installInto, err)
+		return false, fmt.Errorf("reading dir %s: %w", e.installInto, err)
 	}
 	for _, entry := range localEntries {
 		if entry.IsDir() {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -349,9 +349,9 @@ func (e *directoryExtracter) checkMissingFiles(ctx context.Context, installInto 
 		remoteMap[path.Base(targetPath)] = struct{}{}
 	}
 
-	localEntries, err := os.ReadDir(e.installInto)
+	localEntries, err := os.ReadDir(installInto)
 	if err != nil {
-		return false, fmt.Errorf("reading dir %s: %w", e.installInto, err)
+		return false, fmt.Errorf("reading dir %s: %w", installInto, err)
 	}
 	for _, entry := range localEntries {
 		if entry.IsDir() {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/hashicorp/go-multierror"
 	cp "github.com/otiai10/copy"
 
 	"github.com/vinted/S3Grabber/internal/downloader"
@@ -139,7 +140,7 @@ type Installer struct {
 type extracter interface {
 	findNewestFile(ctx context.Context) (lastUpdated time.Time, bucketIndex int, err error)
 	extractFiles(ctx context.Context, bucketIndex int) (bool, error)
-	checkMissingFiles(ctx context.Context) (bool, error)
+	checkMissingFiles(ctx context.Context) ([]string, error)
 }
 
 func NewArchiveInstaller(name string, bm *downloader.BucketManager, commands []string, bucketPath, installInto string, shellCmd string, timeout time.Duration, replacePrefix string, logger log.Logger) *Installer {
@@ -218,13 +219,21 @@ func (i *Installer) Install(ctx context.Context) (attemptedInstall bool, rerr er
 		doInstall = true
 	}
 
+	// If we are not going to install, check if there are files that are present locally but missing remotely in any of the buckets and remove them
 	if !doInstall {
-		hasMissingFiles, err := i.extracter.checkMissingFiles(ctx)
+		missingLocalFiles, err := i.extracter.checkMissingFiles(ctx)
 		if err != nil {
 			_ = level.Error(i.logger).Log("msg", "failed to check for missing files", "err", err.Error(), "dir", i.installInto)
-		} else if hasMissingFiles {
-			_ = level.Debug(i.logger).Log("msg", "executing installation because files are missing", "dir", i.installInto, "path", i.bucketPath)
-			doInstall = true
+		} else if len(missingLocalFiles) > 0 {
+			var errs error
+			for _, localFile := range missingLocalFiles {
+				_ = level.Debug(i.logger).Log("msg", "removing local files that are missing on remote", "file", localFile)
+				if err := os.Remove(localFile); err != nil {
+					errs = multierror.Append(errs, fmt.Errorf("removing missing local file %s: %w", localFile, err))
+					continue
+				}
+			}
+			return true, errs
 		}
 	}
 
@@ -305,9 +314,9 @@ func (e *archiveExtracter) findNewestFile(ctx context.Context) (lastUpdated time
 	return e.bm.FindNewestFile(ctx, e.bucketPath)
 }
 
-func (e *archiveExtracter) checkMissingFiles(ctx context.Context) (bool, error) {
+func (e *archiveExtracter) checkMissingFiles(ctx context.Context) ([]string, error) {
 	// note: in archive case it is sufficient to rely on the modification time check
-	return false, nil
+	return nil, nil
 }
 
 func (e *archiveExtracter) extractFiles(ctx context.Context, bucketIndex int) (bool, error) {
@@ -338,10 +347,13 @@ func (e *directoryExtracter) findNewestFile(ctx context.Context) (lastUpdated ti
 	return e.bm.FindNewestInPrefix(ctx, e.bucketPrefix)
 }
 
-func (e *directoryExtracter) checkMissingFiles(ctx context.Context) (bool, error) {
+// checkMissingFiles compares the files in the local directory with the files in the all remote buckets.
+// Returns list of files (full path) that are present locally but missing remotely in any of the buckets.
+// If replacePrefix is specified, only files matching that prefix are checked.
+func (e *directoryExtracter) checkMissingFiles(ctx context.Context) ([]string, error) {
 	remoteFiles, err := e.bm.ListFiles(ctx, e.bucketPrefix)
 	if err != nil {
-		return false, fmt.Errorf("listing files in bucket: %w", err)
+		return nil, fmt.Errorf("listing files in bucket: %w", err)
 	}
 	// for simplicity, compare file names only.
 	remoteMap := make(map[string]struct{}, len(remoteFiles))
@@ -351,8 +363,9 @@ func (e *directoryExtracter) checkMissingFiles(ctx context.Context) (bool, error
 
 	localEntries, err := os.ReadDir(e.installInto)
 	if err != nil {
-		return false, fmt.Errorf("reading dir %s: %w", e.installInto, err)
+		return nil, fmt.Errorf("reading dir %s: %w", e.installInto, err)
 	}
+	missingLocalFiles := []string{}
 	for _, entry := range localEntries {
 		if entry.IsDir() {
 			continue
@@ -364,11 +377,11 @@ func (e *directoryExtracter) checkMissingFiles(ctx context.Context) (bool, error
 
 		if _, ok := remoteMap[fn]; !ok {
 			_ = level.Debug(e.logger).Log("msg", "file is missing on remote", "file", fn)
-			return true, nil
+			missingLocalFiles = append(missingLocalFiles, path.Join(e.installInto, fn))
 		}
 	}
 
-	return false, nil
+	return missingLocalFiles, nil
 }
 
 func (e *directoryExtracter) extractFiles(ctx context.Context, bucketIndex int) (bool, error) {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -348,8 +348,8 @@ func (e *directoryExtracter) findNewestFile(ctx context.Context) (lastUpdated ti
 	return e.bm.FindNewestInPrefix(ctx, e.bucketPrefix)
 }
 
-// checkMissingFiles compares the files in the local directory with the files in the all remote buckets.
-// Returns list of files (full path) that are present locally but missing remotely in any of the buckets.
+// checkMissingFiles compares the files in the local directory with the files in all remote buckets combined.
+// Returns list of files (full path) that are present locally but missing from all remote buckets.
 // If replacePrefix is specified, only files matching that prefix are checked.
 func (e *directoryExtracter) checkMissingFiles(ctx context.Context) ([]string, error) {
 	remoteFiles, err := e.bm.ListFiles(ctx, e.bucketPrefix)

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -224,6 +224,7 @@ func (i *Installer) Install(ctx context.Context) (attemptedInstall bool, rerr er
 		missingLocalFiles, err := i.extracter.checkMissingFiles(ctx)
 		if err != nil {
 			_ = level.Error(i.logger).Log("msg", "failed to check for missing files", "err", err.Error(), "dir", i.installInto)
+			return false, fmt.Errorf("checking for missing files: %w", err)
 		} else if len(missingLocalFiles) > 0 {
 			var errs error
 			for _, localFile := range missingLocalFiles {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -343,16 +343,27 @@ func (e *directoryExtracter) checkMissingFiles(ctx context.Context, installInto 
 	if err != nil {
 		return false, fmt.Errorf("listing files in bucket: %w", err)
 	}
-
+	// for simplicity, compare file names only.
+	remoteMap := make(map[string]struct{}, len(remoteFiles))
 	for _, targetPath := range remoteFiles {
-		// Apply replacePrefix logic if needed
-		if e.replacePrefix != "" && strings.HasPrefix(targetPath, e.replacePrefix) {
-			targetPath = strings.TrimPrefix(targetPath, e.replacePrefix)
+		remoteMap[path.Base(targetPath)] = struct{}{}
+	}
+
+	localEntries, err := os.ReadDir(e.installInto)
+	if err != nil {
+		return false, fmt.Errorf("reading dir %s: %w", e.installInto, err)
+	}
+	for _, entry := range localEntries {
+		if entry.IsDir() {
+			continue
+		}
+		fn := entry.Name()
+		if e.replacePrefix != "" && !strings.HasPrefix(fn, e.replacePrefix) {
+			continue
 		}
 
-		fullPath := filepath.Join(installInto, targetPath)
-		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-			_ = level.Debug(e.logger).Log("msg", "found missing file", "file", fullPath)
+		if _, ok := remoteMap[fn]; !ok {
+			_ = level.Debug(e.logger).Log("msg", "file is missing on remote", "file", fn)
 			return true, nil
 		}
 	}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -139,6 +139,7 @@ type Installer struct {
 type extracter interface {
 	findNewestFile(ctx context.Context) (lastUpdated time.Time, bucketIndex int, err error)
 	extractFiles(ctx context.Context, bucketIndex int) (bool, error)
+	checkMissingFiles(ctx context.Context, installInto string) (bool, error)
 }
 
 func NewArchiveInstaller(name string, bm *downloader.BucketManager, commands []string, bucketPath, installInto string, shellCmd string, timeout time.Duration, replacePrefix string, logger log.Logger) *Installer {
@@ -218,6 +219,16 @@ func (i *Installer) Install(ctx context.Context) (attemptedInstall bool, rerr er
 	}
 
 	if !doInstall {
+		hasMissingFiles, err := i.extracter.checkMissingFiles(ctx, i.installInto)
+		if err != nil {
+			_ = level.Debug(i.logger).Log("msg", "failed to check for missing files", "err", err.Error(), "dir", i.installInto)
+		} else if hasMissingFiles {
+			_ = level.Debug(i.logger).Log("msg", "executing installation because files are missing", "dir", i.installInto, "path", i.bucketPath)
+			doInstall = true
+		}
+	}
+
+	if !doInstall {
 		return false, nil
 	}
 
@@ -294,6 +305,11 @@ func (e *archiveExtracter) findNewestFile(ctx context.Context) (lastUpdated time
 	return e.bm.FindNewestFile(ctx, e.bucketPath)
 }
 
+func (e *archiveExtracter) checkMissingFiles(ctx context.Context, installInto string) (bool, error) {
+	// note: in archive case it is sufficient to rely on the modification time check
+	return false, nil
+}
+
 func (e *archiveExtracter) extractFiles(ctx context.Context, bucketIndex int) (bool, error) {
 	rc, err := e.bm.GetFile(ctx, e.bucketPath, bucketIndex)
 	if err != nil {
@@ -320,6 +336,28 @@ type directoryExtracter struct {
 
 func (e *directoryExtracter) findNewestFile(ctx context.Context) (lastUpdated time.Time, bucketIndex int, err error) {
 	return e.bm.FindNewestInPrefix(ctx, e.bucketPrefix)
+}
+
+func (e *directoryExtracter) checkMissingFiles(ctx context.Context, installInto string) (bool, error) {
+	remoteFiles, err := e.bm.ListFiles(ctx, e.bucketPrefix)
+	if err != nil {
+		return false, fmt.Errorf("listing files in bucket: %w", err)
+	}
+
+	for _, targetPath := range remoteFiles {
+		// Apply replacePrefix logic if needed
+		if e.replacePrefix != "" && strings.HasPrefix(targetPath, e.replacePrefix) {
+			targetPath = strings.TrimPrefix(targetPath, e.replacePrefix)
+		}
+
+		fullPath := filepath.Join(installInto, targetPath)
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			_ = level.Debug(e.logger).Log("msg", "found missing file", "file", fullPath)
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (e *directoryExtracter) extractFiles(ctx context.Context, bucketIndex int) (bool, error) {

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -106,6 +106,14 @@ func TestS3GrabberMain(t *testing.T) {
 	isEmpty, err := installer.IsEmptyDir(tmpDirArchive)
 	require.NoError(t, err)
 	require.Equal(t, false, isEmpty)
+
+	require.NoError(t, bm.DeleteFile(context.Background(), "exampledir/dir_file2.txt", 1))
+	attemptedInstall, err = s3grabber.RunS3Grabber(log.NewLogfmtLogger(os.Stderr), grabberCfg)
+	require.NoError(t, err)
+	require.True(t, attemptedInstall)
+	checkFileContentEqual(t, filepath.Join(tmpDirDir, "dir_file1.txt"), "test1\n")
+	checkFileMissing(t, filepath.Join(tmpDirDir, "dir_file2.txt"))
+
 }
 
 func checkFileContentEqual(t *testing.T, path, content string) {
@@ -117,5 +125,9 @@ func checkFileContentEqual(t *testing.T, path, content string) {
 	fileContent, err := io.ReadAll(f)
 	require.Nil(t, err)
 	require.Equal(t, string(fileContent), string(content))
+}
 
+func checkFileMissing(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "File should not exist: %s", path)
 }

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/stretchr/testify/require"
 	"github.com/vinted/S3Grabber/internal/cfg"
 	"github.com/vinted/S3Grabber/internal/downloader"
@@ -34,6 +35,7 @@ func TestS3GrabberMain(t *testing.T) {
 		require.Nil(t, os.RemoveAll(tmpDirDir))
 	})
 
+	dirPrefix := "dir_"
 	grabberCfg := cfg.GlobalConfig{
 		Buckets: map[string]cfg.BucketConfig{
 			"test1": {
@@ -59,12 +61,13 @@ func TestS3GrabberMain(t *testing.T) {
 				Shell:    "/bin/sh",
 			},
 			"testing_dir": {
-				Buckets:  []string{"test2"},
-				Dir:      &dirName,
-				Path:     tmpDirDir,
-				Commands: []string{fmt.Sprintf("echo foobar > %s", filepath.Join(tmpDirDir, "some_dir_file"))},
-				Timeout:  5 * time.Second,
-				Shell:    "/bin/sh",
+				Buckets:       []string{"test2"},
+				Dir:           &dirName,
+				Path:          tmpDirDir,
+				Commands:      []string{fmt.Sprintf("echo foobar > %s", filepath.Join(tmpDirDir, "some_dir_file"))},
+				Timeout:       5 * time.Second,
+				Shell:         "/bin/sh",
+				ReplacePrefix: &dirPrefix,
 			},
 		},
 	}
@@ -108,12 +111,16 @@ func TestS3GrabberMain(t *testing.T) {
 	require.Equal(t, false, isEmpty)
 
 	require.NoError(t, bm.DeleteFile(context.Background(), "exampledir/dir_file2.txt", 1))
-	attemptedInstall, err = s3grabber.RunS3Grabber(log.NewLogfmtLogger(os.Stderr), grabberCfg)
+	attemptedInstall, err = s3grabber.RunS3Grabber(debugLogger(), grabberCfg)
 	require.NoError(t, err)
 	require.True(t, attemptedInstall)
-	checkFileContentEqual(t, filepath.Join(tmpDirDir, "dir_file1.txt"), "test1\n")
+	checkFileExist(t, filepath.Join(tmpDirDir, "dir_file1.txt"))
 	checkFileMissing(t, filepath.Join(tmpDirDir, "dir_file2.txt"))
+}
 
+func debugLogger() log.Logger {
+	logger := log.NewLogfmtLogger(os.Stderr)
+	return level.NewFilter(logger, level.AllowDebug())
 }
 
 func checkFileContentEqual(t *testing.T, path, content string) {
@@ -125,6 +132,11 @@ func checkFileContentEqual(t *testing.T, path, content string) {
 	fileContent, err := io.ReadAll(f)
 	require.Nil(t, err)
 	require.Equal(t, string(fileContent), string(content))
+}
+
+func checkFileExist(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	require.NoError(t, err, "File should exist: %s", path)
 }
 
 func checkFileMissing(t *testing.T, path string) {


### PR DESCRIPTION
Previously, when a file was deleted from the upstream bucket, the installer
was not triggered and the corresponding local file remained untouched.

S3Grabber now enforces that every local file must have a matching entity in at
least one remote bucket. When `replace_prefix` is set, only prefixed files are
considered for comparison. If a local file is not found in any remote bucket,
it is treated as stale and removed.